### PR TITLE
Fix unit tests

### DIFF
--- a/BuildEngineMapReaderTests/BuildEngineMapReaderTests.csproj
+++ b/BuildEngineMapReaderTests/BuildEngineMapReaderTests.csproj
@@ -13,6 +13,8 @@
     <ProjectReference Include="..\BuildEngineMapReader\BuildEngineMapReader.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/BuildEngineMapReaderTests/MapFileReaderTest.cs
+++ b/BuildEngineMapReaderTests/MapFileReaderTest.cs
@@ -10,7 +10,7 @@ namespace BuildEngineMapReaderTests
         [Test]
         public void ShouldParseBuildMap()
         {
-            const string filePath = "/Users/thomas.rosenquist/git/BuildEngineMapReader/Maps/THE_BASE.MAP";
+            const string filePath = "../../../../Maps/THE_BASE.MAP";
             var mapFileReader = new MapFileReader();
             var map = mapFileReader.ReadFile(filePath);
             Console.WriteLine(map);


### PR DESCRIPTION
- went back to NUnit3 as 4 is not yet stable I think
- added Nunit3TestAdapter and .NET.Test.Sdk in Nuget

This should make the tests run but there's a reference to a map file that only exists on your machine so this will likely fail unless you push the test map to the repo.